### PR TITLE
Content fixes to: - home page - footer - about

### DIFF
--- a/app/views/pages/2015-hackathon.html.erb
+++ b/app/views/pages/2015-hackathon.html.erb
@@ -1,74 +1,17 @@
-<%= content_for :page_title, 'Summer 2015 Hackathon' %>
+<%= content_for :page_title, 'Winter 2015 Hackathon' %>
 
 <div class="content">
 	<div class="leftcolumn">
-		<h3>This summer, Greensboro will have its very first civic hackathon. And we want you to be there.</h3>
+		<h3>This November, Code for Greensboro will host the second civic hackathon of the year. </h3>
 
 		<h5>
-			What is this thing?
+			Didn't we just do this?
 		</h5>
 
 		<p>
-			June 6, 2015 is the <%= link_to "National Day Of Civic Hacking", "http://hackforchange.org" %>, and we'll be celebrating with a hackathon. What can we do when we put all of Greensboro's most passionate developers, designers, data junkies, policy wonks, community organizers and engaged citizens in one place for a day? A lot, that's what. Join us as we identify civic problems, build solutions that use real data to solve those problems, and have an amazing time doing it.
+			Save the date and stayed tuned for updates. You'll want to get your tickets early this time. Watch for the announcement.
 		</p>
-
-		<p>
-			Bring your laptop, an open mind, and your best ideas. We'll bring the data, a love for Greensboro and all it can be, and some pioneering spirit to share.
-		</p>
-
-		<p>
-			This event is <em><%= link_to "huge", "https://www.whitehouse.gov/blog/2015/05/12/save-date-national-day-civic-hacking-coming-june-6" %></em>, and we're incredibly excited to take part. We'll be working together on some of the <%= link_to "challenges", "http://hackforchange.org/challenges/"%> outlined by Code for America, as well as independent projects&mdash;maybe even something you bring with you.
-		</p>
-
-		<h5>
-			When and Where?
-		</h5>
-
-		<p>
-			This summer we'll be at Co//ab, a co-working and entrepreneurship space in Greensboro.
-		</p>
-		<ul>
-			<li>Co//ab</li>
-			<li>229 N. Greene St.</li>
-			<li>Greensboro, NC 27401</li>
-			<li>June 6, 2015 from 10 AM</li>
-			<li>June 7, 2015 from 10 AM</li>
-		</ul>
-
-		</br>
-
-		<h5>
-			What else do I need to know?
-		</h5>
-
-		<p>
-			We'll have caffeine (and non-caffeine), food, schwag from our sponsors and blazing fast gigabit internet from our friends at North State.
-		</p>
-
-		<h3>
-			Saturday
-		</h3>
-
-		<p>
-			We'll meet up and break into groups and begin working on projects. Bring your laptop and/or your tools of choice (UI stencils, pads, pens, art supplies, etc.) Offer your services to a group, head a project, or learn a new skill or framework. Do research. Learn about your city from the inside out.
-		</p>
-
-		<h3>
-			Sunday
-		</h3>
-
-		<p>
-			Sunday we'll convene again to take stock of what we've created. By then, we hope you'll have learned some new things and made some new friends.
-		</p>
-
-		<h5>
-			Where can I register (and what will it cost?)
-		</h5>
-
-		<p>
-		<%= link_to "Register here", "http://www.eventbrite.com/e/code-for-greensboro-civic-hackathon-2015-tickets-16804960088?aff=eac2" %> for admission. And the cost is <strong>free</strong>!
-		</p>
-		</div>
+	</div>
 		<aside class="sidebar">
 			<%= image_tag "hackathon-logo.jpg" %>
 

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -15,7 +15,7 @@
 
 		<h5>For Example</h5>
 
-		<p>What sorts of projects do we do? Mapping and recording the status of fire hydrants. Tracking storm water data. Building apps that report trash collection times and let citizens report missed pickups. In short, the projects we undertake improve the parts of city government that would be "nice to have", but that—in the course of running an entire city—can sometimes be forgotten. Take a look at the <%=link_to "agenda", "https://docs.google.com/document/d/1EZo56RobNtodRbKshRrJsJKsX2PsCCCi_e-HVXno2so/edit?usp=sharing" %> for our next meetup and bring your own ideas that night!</p>
+		<p>What sorts of projects do we do? Mapping and recording the status of fire hydrants. Tracking storm water data. Building apps that report trash collection times and let citizens report missed pickups. In short, the projects we undertake improve the parts of city government that would be "nice to have", but that—in the course of running an entire city—can sometimes be forgotten.</p>
 
 		<h5>Is This Just For Coders?</h5>
 
@@ -23,7 +23,7 @@
 
 		<h5>What goes on at our meetups?</h5>
 
-		<p>We start every meetup with introductions and a welcome to new members. From there we move into a Lightning Talk or update from Members who have attended community events, meetings, or anything else that would interest the Brigade. There is time set aside for discussion of new ideas or existing <%=link_to "Code for America projects", "http://www.codeforamerica.org/apps/" %> that we may want to work on - feel free to bring in ideas! After that, our teams will give quick project status updates and let everyone know what they need help with that night - and then the work begins.</p>
+		<p>We start every meetup with introductions and a welcome to new members. From there we move into a Lightning Talk or updates from members who have attended community events, meetings, or anything else that would interest the Brigade. After that, our Project Leads will give quick project status updates and let everyone know what they need help with that night - and then the work begins.</p>
 
 		<p>Have an idea for a Lightning Talk you'd like to hear? Want to sign up to give one? Add to the list or assign a topic to yourself <%=link_to "here", "https://github.com/codeforgso/lightning-talks/issues" %>. Not a member of our GitHub organization? Let us know by jumping into Slack and messaging Anita, Nick or Jason. <%=link_to "Need a Slack invite", "http://slack.codeforgreensboro.org" %>? We hope to see you at our next <%=link_to "Meetup", "http://www.meetup.com/Code-for-Greensboro/" %>!
 	</div>

--- a/app/views/pages/code-of-conduct.html.erb
+++ b/app/views/pages/code-of-conduct.html.erb
@@ -1,11 +1,5 @@
 <%= content_for :page_title, 'Code of Conduct' %>
 
-<header class="internal">
-	<div class="content">
-		<h2 class="darken"><%= yield :page_title %></h2>
-	</div>
-</header>
-
 <div class="content">
 
 	<h4>
@@ -49,7 +43,7 @@
 
 	<p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for America network activities, events, and digital forums. </p>
 
-	<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff or forum administrator immediately. You can contact them at [Anita Cafiero, <a href="mailto:anita@tinygoatstudio.com">anita@tinygoatstudio.com</a>, 804-503-5832]. Event staff or forum administrators will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.</p>
+	<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff or forum administrator immediately. You can contact them at [Anita Cafiero, <a href="mailto:anita@codeforgreensboro.org">anita@codeforgreensboro.org</a>, 804-503-5832]. Event staff or forum administrators will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.</p>
 
 	<p>If you cannot reach an event organizer or forum administrator and/or it is an emergency, please call 911 and/or remove yourself from the situation. </p>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,7 +5,7 @@
 			<ul>
 				<li><%=link_to "Home", root_path %></li>
 				<li><%=link_to "About", static_path('about') %></li>
-				<li><%=link_to "Leadership", static_path('leadership') %></li>
+				<li><%=link_to "Our Team", static_path('leadership') %></li>
 				<li><%=link_to "Contact", static_path('contact') %></li>
 			</ul>
 			<ul>
@@ -13,7 +13,7 @@
 				<li><%=link_to "Github Team", "https://github.com/codeforgso" %></li>
 				<li><%=link_to "Slack", "http://slack.codeforgreensboro.org" %></li>
 				<li><%=link_to "Twitter", "http://www.twitter.com/codeforgso" %></li>
-				
+
 			</ul>
 		</div>
 		<div class="panel three-up">


### PR DESCRIPTION
Fix for double header on 'code of conduct' page
